### PR TITLE
updating mypy readme docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mypy-check
 
-GitHub Action for [mypy](https://mypy.readthedocs.io/en/master/)
+GitHub Action for [mypy](https://mypy.readthedocs.io/en/stable/)
 
 Make sure you have a `mypy.ini` or `setup.cfg` file at the root of your repository!
 


### PR DESCRIPTION
The link in README redirects to a not found page. Fixed it to redirect it to the correct page.